### PR TITLE
Wait for tester to settle

### DIFF
--- a/test/auth_section/create_account/widget_test.dart
+++ b/test/auth_section/create_account/widget_test.dart
@@ -18,7 +18,7 @@ class MockNavigatorObserver extends Mock implements NavigatorObserver {}
 
 void main() {
   Widget makeTestableCreateAccountWidget(MockNavService mockNavService,
-      MockAuthService mockAuth, MockDBService mockDBService) {
+      MockAuthService mockAuth, MockDatabaseService mockDBService) {
     return MultiProvider(
         providers: [
           Provider<AuthService>(create: (_) => mockAuth),
@@ -42,7 +42,7 @@ void main() {
           controller: _controller,
           mockUserData: _mockUserData,
           mockNavService: _mockNavService);
-      final _mockDBService = MockDBService();
+      final _mockDBService = MockDatabaseService();
       await tester.pumpWidget(makeTestableCreateAccountWidget(
         _mockNavService,
         _mockAuthService,
@@ -90,7 +90,7 @@ void main() {
           controller: _controller,
           mockUserData: _mockUserData,
           mockNavService: _mockNavService);
-      final _mockDBService = MockDBService();
+      final _mockDBService = MockDatabaseService();
       await tester.pumpWidget(makeTestableCreateAccountWidget(
         _mockNavService,
         _mockAuthService,
@@ -119,7 +119,7 @@ void main() {
           controller: _controller,
           mockUserData: _mockUserData,
           mockNavService: _mockNavService);
-      final _mockDBService = MockDBService();
+      final _mockDBService = MockDatabaseService();
       await tester.pumpWidget(makeTestableCreateAccountWidget(
         _mockNavService,
         _mockAuthService,
@@ -162,7 +162,7 @@ void main() {
           controller: _controller,
           mockUserData: _mockUserData,
           mockNavService: _mockNavService);
-      final _mockDBService = MockDBService();
+      final _mockDBService = MockDatabaseService();
       await tester.pumpWidget(makeTestableCreateAccountWidget(
         _mockNavService,
         _mockAuthService,

--- a/test/mocks/services/mock_database_service.dart
+++ b/test/mocks/services/mock_database_service.dart
@@ -3,10 +3,10 @@ import 'dart:async';
 import 'package:niira/models/game.dart';
 import 'package:niira/services/database/database_service.dart';
 
-class MockDBService implements DatabaseService {
+class MockDatabaseService implements DatabaseService {
   final StreamController<List<Game>> _controller;
 
-  MockDBService({
+  MockDatabaseService({
     StreamController<List<Game>> controller,
   }) : _controller = controller;
 

--- a/test_driver/app.dart
+++ b/test_driver/app.dart
@@ -20,7 +20,7 @@ void main() {
     mockUserData: mockUserData,
     mockNavService: mockNavService,
   );
-  final mockDBService = MockDBService();
+  final mockDBService = MockDatabaseService();
   mockAuthService.signInWithEmail('email', 'password');
 
   runApp(MyApp(

--- a/test_driver/mocks/services/mock_database_service.dart
+++ b/test_driver/mocks/services/mock_database_service.dart
@@ -1,12 +1,13 @@
 import 'dart:async';
-import 'package:niira/models/game.dart';
+
 import 'package:meta/meta.dart';
+import 'package:niira/models/game.dart';
 import 'package:niira/services/database/database_service.dart';
 
-class MockDBService implements DatabaseService {
+class MockDatabaseService implements DatabaseService {
   final StreamController<List<Game>> _controller;
 
-  MockDBService({
+  MockDatabaseService({
     @required StreamController<List<Game>> controller,
   }) : _controller = controller;
 


### PR DESCRIPTION
- another cheeky rename
- added a pumpAndSettle call after widget pump

@tamari-gray hey mate, see what you think - I think we just needed to let the tester settle so the stream builder had the correct data from the stream. 

Also I couldn't help myself and renamed MockDBService to MockDatabaseService  :-) 
(just because I wasted some time figuring out that the file was named differently to the class) 